### PR TITLE
Make CustomDropdown.xml offline capable

### DIFF
--- a/src/CustomDropdown.xml
+++ b/src/CustomDropdown.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<widget id="mendix.customdropdown.CustomDropdown" pluginWidget="true" needsEntityContext="true" offlineCapable="false"
+<widget id="mendix.customdropdown.CustomDropdown" pluginWidget="true" needsEntityContext="true" offlineCapable="true"
         supportedPlatform="Web"
         xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">


### PR DESCRIPTION
The widget is offline capable.
If I change in the 2nd line of CustomDropdown.xml offlineCapable="true" then I can use it in an offline app and it works. If I don't add this Mendix Studio Pro complains:
Custom widget 'Custom Dropdown' is not offline capable and cannot be used on pages that are accessible through an offline profile.

In an offline app the data needs to be of course first synced to the offline app and then Nanoflow needs to be used instead of Microflows. But I used, tested and confirmed that it works correctly.